### PR TITLE
updating import links for shim and peer package

### DIFF
--- a/config/chaincode/chaincode_example02/chaincode_example02.go
+++ b/config/chaincode/chaincode_example02/chaincode_example02.go
@@ -26,8 +26,8 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/hyperledger/fabric/core/chaincode/shim"
-	pb "github.com/hyperledger/fabric/protos/peer"
+	"github.com/hyperledger/fabric-chaincode-go/shim"
+	sc "github.com/hyperledger/fabric-protos-go/peer"
 )
 
 // SimpleChaincode example simple Chaincode implementation


### PR DESCRIPTION
The shim and peer protobuf modules are no longer vendored automatically by Fabric, so they are needed to vendor individually otherwise they lead to the issue as depicted in the attached screenshot.

![chaincode_go_import-error](https://user-images.githubusercontent.com/48702793/131339948-4f733c74-c189-4e82-88d9-9ef6bcb13e9f.png)
